### PR TITLE
Comments out glossary generation step

### DIFF
--- a/.github/workflows/update_release.yml
+++ b/.github/workflows/update_release.yml
@@ -57,9 +57,9 @@ jobs:
           sed -i "s/{{ release_number }}/$RELEASE_TAG/g" docs/stylesheets/pdf.css
 
       # Step 6: Run the glossary processing script
-      - name: Generate glossary annex
-        run: |
-          python process_glossary.py
+#      - name: Generate glossary annex
+#        run: |
+#          python process_glossary.py
 
       # Step 7: Set EXPORT_PDF environment variable
       - name: Set EXPORT_PDF environment variable


### PR DESCRIPTION
Comments out the glossary generation step in the release workflow.

This is likely a temporary measure or an intentional decision to exclude the glossary generation from the automated release process for some reason.

## Documentation Update Template

### Related Issue(s)
<!--- This project only accepts pull requests related to open issues. If no such corresponding issue exists, you must report one before submitting the pull request. The "Fixes #" text must be present to properly close the issue when the request is accepted. 
e.g., Fixes #123. If multiple issued are corrected, 
- Fixes #123
- Fixes #124 -->

Fixes #<Issue number>

### Type of Change
e.g., typo fix, new subsection to address API update, removed ambiguity, updated yml file to support new documentation feature

### Summary of the Update
<!-- Provide a brief summary of the documentation update.
- What sections were changed?
- What was changed?
- Why is this update necessary? -->
e.g., Section 3.2.7 was inserted to add the requirement suggested by the reported issue; subsequent sections were renumbered.

### **Type of Documentation Update**
Select the type of documentation update you are submitting:

- [ ] New documentation
- [ ] Changes to existing documentation
- [ ] Bug fix or correction
- [ ] Removal of deprecated documentation

### **Checklist**
Before submitting, please ensure the following items are checked:

- [ ] I have verified that the changes are accurate and reflect the current state of the project.
- [ ] The documentation follows the existing style guidelines and structure.
- [ ] I have included all necessary references, links, and examples (if applicable).
- [ ] Screenshots or examples have been updated (if applicable).
- [ ] I have reviewed the changes for spelling and grammar issues.
- [ ] All sections of the documentation affected by the update have been checked for consistency.

---

### **Additional Notes**
Include any additional information or comments here (optional):